### PR TITLE
IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All you need is an AWS account and the ability to create an AWS role and EC2 ins
 1. Log into your AWS account and access the Identity and Access Management (IAM) service in the AWS Management Console, then choose [**Create Role**](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html) (you can also use the AWS CLI if you prefer)
 2. Select **AWS service** for type of trusted entity
 3. Select **EC2** as the allowed service and use case, then choose **Next: Permissions**
-4. Select the [**AmazonEC2FullAccess**](https://console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn%3Aaws%3Aiam%3A%3Aaws%3Apolicy%2FAmazonEC2FullAccess) policy or paste [our recommended less-permissive policy](https://github.com/rpetrich/patrolaroid/tree/main/docs/recommended-iam-policy.md) into [the JSON editor](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create-console.html#access_policies_create-json-editor). Then choose **Next: Tags**
+4. Select the [**AmazonEC2FullAccess**](https://console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn%3Aaws%3Aiam%3A%3Aaws%3Apolicy%2FAmazonEC2FullAccess) policy or paste [our recommended policy](https://github.com/rpetrich/patrolaroid/tree/main/docs/recommended-iam-policy.md) (with tighter permissions) into [the JSON editor](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create-console.html#access_policies_create-json-editor), then choose **Next: Tags**
 5. No tags are needed, so select **Next: Review**
 6. Type **Patrolaroid** for the **Role name**
 7. Review the role and, if satisfied, choose **Create role**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All you need is an AWS account and the ability to create an AWS role and EC2 ins
 1. Log into your AWS account and access the Identity and Access Management (IAM) service in the AWS Management Console, then choose [**Create Role**](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html) (you can also use the AWS CLI if you prefer)
 2. Select **AWS service** for type of trusted entity
 3. Select **EC2** as the allowed service and use case, then choose **Next: Permissions**
-4. Select the [**AmazonEC2FullAccess**](https://console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn%3Aaws%3Aiam%3A%3Aaws%3Apolicy%2FAmazonEC2FullAccess) policy, then choose **Next: Tags**
+4. Select the [**AmazonEC2FullAccess**](https://console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn%3Aaws%3Aiam%3A%3Aaws%3Apolicy%2FAmazonEC2FullAccess) policy or paste [our recommended less-permissive policy](https://github.com/rpetrich/patrolaroid/tree/main/docs/recommended-iam-policy.md) into [the JSON editor](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create-console.html#access_policies_create-json-editor). Then choose **Next: Tags**
 5. No tags are needed, so select **Next: Review**
 6. Type **Patrolaroid** for the **Role name**
 7. Review the role and, if satisfied, choose **Create role**

--- a/docs/recommended-iam-policy.md
+++ b/docs/recommended-iam-policy.md
@@ -1,6 +1,6 @@
 # Recommended AWS IAM policy
 
-For individuals more comfortable applying [custom IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) in AWS, we recommend using the below IAM policy instead of `AmazonEC2FullAccess` when creating the AWS role for Patrolaroid. 
+For individuals comfortable applying [custom IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) in AWS, we recommend using the below IAM policy instead of `AmazonEC2FullAccess` when creating the AWS role for Patrolaroid. 
 
 ```
 {

--- a/docs/recommended-iam-policy.md
+++ b/docs/recommended-iam-policy.md
@@ -1,0 +1,27 @@
+# Recommended AWS IAM policy
+
+For individuals more comfortable applying [custom IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) in AWS, we recommend using the below IAM policy instead of `AmazonEC2FullAccess` when creating the AWS role for Patrolaroid. 
+
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Stmt1622650196578",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:CreateSnapshot",
+        "ec2:CreateVolume",
+        "ec2:DeleteVolume",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeVolumes",
+        "ec2:DetachVolume"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Thanks to @Jonty for the suggestion.


### PR DESCRIPTION
Adds a docs folder with a MD file containing a recommended IAM policy for the Patrolaroid role. The link in the Getting Started guide is borked but I think should work once the /docs/ subfolder is merged into main. (Trees are hard.)

Closes #6